### PR TITLE
--password-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ etcdtool -d -c etcdtool.toml edit -v -f toml /hosts/test2.example.com
 etcdtool -d -c etcdtool.toml validate /hosts
 ```
 
+**Authentication**
+
+These commands will prompt you for the password for the user. Alternatively, you
+can pass the password in a file with `--password-file` or `-F`:  
+
+```
+cat /path/to/passwordfile
+passwordstring
+
+etcdtool -password-file /path/to/passwordfile validate /hosts
+```
+
 # Caveats
 
 - etcd doesn't support list's, this is handled by using the index as the key:

--- a/src/github.com/mickep76/etcdtool/command/config.go
+++ b/src/github.com/mickep76/etcdtool/command/config.go
@@ -11,14 +11,15 @@ import (
 
 // Etcdtool configuration struct.
 type Etcdtool struct {
-	Peers          string        `json:"peers,omitempty" yaml:"peers,omitempty" toml:"peers,omitempty"`
-	Cert           string        `json:"cert,omitempty" yaml:"cert,omitempty" toml:"cert,omitempty"`
-	Key            string        `json:"key,omitempty" yaml:"key,omitempty" toml:"key,omitempty"`
-	CA             string        `json:"ca,omitempty" yaml:"ca,omitempty" toml:"peers,omitempty"`
-	User           string        `json:"user,omitempty" yaml:"user,omitempty" toml:"user,omitempty"`
-	Timeout        time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" toml:"timeout,omitempty"`
-	CommandTimeout time.Duration `json:"commandTimeout,omitempty" yaml:"commandTimeout,omitempty" toml:"commandTimeout,omitempty"`
-	Routes         []Route       `json:"routes" yaml:"routes" toml:"routes"`
+	Peers            string        `json:"peers,omitempty" yaml:"peers,omitempty" toml:"peers,omitempty"`
+	Cert             string        `json:"cert,omitempty" yaml:"cert,omitempty" toml:"cert,omitempty"`
+	Key              string        `json:"key,omitempty" yaml:"key,omitempty" toml:"key,omitempty"`
+	CA               string        `json:"ca,omitempty" yaml:"ca,omitempty" toml:"peers,omitempty"`
+	User             string        `json:"user,omitempty" yaml:"user,omitempty" toml:"user,omitempty"`
+	Timeout          time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" toml:"timeout,omitempty"`
+	CommandTimeout   time.Duration `json:"commandTimeout,omitempty" yaml:"commandTimeout,omitempty" toml:"commandTimeout,omitempty"`
+	Routes           []Route       `json:"routes" yaml:"routes" toml:"routes"`
+	PasswordFilePath string
 }
 
 // Route configuration struct.
@@ -95,6 +96,11 @@ func loadConfig(c *cli.Context) Etcdtool {
 
 	if c.GlobalDuration("command-timeout") != 0 {
 		e.CommandTimeout = c.GlobalDuration("command-timeout")
+	}
+
+	// Add password file path if set
+	if c.GlobalString("password-file") != "" {
+		e.PasswordFilePath = c.GlobalString("password-file")
 	}
 
 	return e

--- a/src/github.com/mickep76/etcdtool/command/connect.go
+++ b/src/github.com/mickep76/etcdtool/command/connect.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -42,9 +43,17 @@ func newClient(e Etcdtool) client.Client {
 	if e.User != "" {
 		cfg.Username = e.User
 		var err error
-		cfg.Password, err = speakeasy.Ask("Password: ")
-		if err != nil {
-			fatal(err.Error())
+		if e.PasswordFilePath != "" {
+			passBytes, err := ioutil.ReadFile(e.PasswordFilePath)
+			if err != nil {
+				fatal(err.Error())
+			}
+			cfg.Password = strings.TrimRight(string(passBytes), "\n")
+		} else {
+			cfg.Password, err = speakeasy.Ask("Password: ")
+			if err != nil {
+				fatal(err.Error())
+			}
 		}
 	}
 

--- a/src/github.com/mickep76/etcdtool/main.go
+++ b/src/github.com/mickep76/etcdtool/main.go
@@ -21,6 +21,7 @@ func main() {
 		cli.StringFlag{Name: "key", Value: "", EnvVar: "ETCDTOOL_KEY", Usage: "Identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca", Value: "", EnvVar: "ETCDTOOL_CA", Usage: "Verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "user, u", Value: "", Usage: "User"},
+		cli.StringFlag{Name: "password-file, F", Value: "", Usage: "File path to the user's password"},
 		cli.DurationFlag{Name: "timeout, t", Value: time.Second, Usage: "Connection timeout"},
 		cli.DurationFlag{Name: "command-timeout, T", Value: 5 * time.Second, Usage: "Command timeout"},
 	}


### PR DESCRIPTION
Adding a `--password-file` flag that allows the user to pass a file with a password instead of getting prompted for the password. Applies to all commands.

Closes #16 

(I can bump the version # if you want)