### PR TITLE
Num infer list option to keep original json when directories are expo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ etcdtool import /hosts/test2.example.com test2.example.com.json
 ```
 etcdtool tree /
 etcdtool export /
+
+**Export the content and infer numbers lists to keep original json:**
+etcdtool export / --num-infer-list
 ```
 
 **Validate data with different routes:**

--- a/examples/host/array.example.com.json
+++ b/examples/host/array.example.com.json
@@ -15,5 +15,5 @@
     }
   },
   "array_test":["first_elem","second_elem","third_elem"],
-  "array_two_levels":[["first_elem","second_elem"],["third_elem"]]
+  "array_two_levels":[["first_elem","second_elem"],["third_elem"], 5, 5.0, true]
 }

--- a/examples/host/array.example.com.json
+++ b/examples/host/array.example.com.json
@@ -1,0 +1,19 @@
+{
+  "site": "emea-nl-1",
+  "tenant": "ops",
+  "interfaces": {
+    "eth0": {
+      "gw": "192.168.0.1",
+      "hwaddr": "00:01:02:03:04:05",
+      "ip": "192.168.0.2",
+      "netmask": "255.255.255.0",
+      "array_insice_map":[
+        { "key1": "value1"},
+        { "key2": "value2"},
+        { "key3": "value3"}
+      ]
+    }
+  },
+  "array_test":["first_elem","second_elem","third_elem"],
+  "array_two_levels":[["first_elem","second_elem"],["third_elem"]]
+}

--- a/src/github.com/mickep76/etcdtool/command/export_command.go
+++ b/src/github.com/mickep76/etcdtool/command/export_command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"github.com/mickep76/etcdmap"
 	"github.com/mickep76/iodatafmt"
+	"strconv"
 )
 
 // NewExportCommand returns data from export.
@@ -18,6 +19,7 @@ func NewExportCommand() cli.Command {
 			cli.BoolFlag{Name: "sort, s", Usage: "returns result in sorted order"},
 			cli.StringFlag{Name: "format, f", EnvVar: "ETCDTOOL_FORMAT", Value: "JSON", Usage: "Data serialization format YAML, TOML or JSON"},
 			cli.StringFlag{Name: "output, o", Value: "", Usage: "Output file"},
+			cli.BoolFlag{Name: "num-infer-list", Usage: "returns result without extra levels of arrays"},
 		},
 		Action: func(c *cli.Context) error {
 			exportCommandFunc(c)
@@ -65,11 +67,95 @@ func exportFunc(dir string, sort bool, file string, f iodatafmt.DataFmt, c *cli.
 		fatal(err.Error())
 	}
 
-	// Export and write output.
 	m := etcdmap.Map(resp.Node)
+	if c.Bool("num-infer-list") {
+		m1 := removeExtraNumbersLevels(m)
+		value, ok := m1.(map[string]interface{})
+		if ok {
+			m = value
+		}
+	}
+
+	// Export and write output.
 	if file != "" {
 		iodatafmt.Write(file, m, f)
 	} else {
 		iodatafmt.Print(m, f)
 	}
 }
+/*
+	Remove extra levels of numbers created in etcd.
+ */
+func removeExtraNumbersLevels(etcdmapObject interface{}) interface{} {
+
+	var result map[string]interface{} = make(map[string]interface{})
+	// START TRAVERSE MAP
+	switch etcdmapObject.(type) {
+	case map[string]interface{}: // map {string, K} case
+
+		for k, v := range etcdmapObject.(map[string]interface{}) {
+			// START TRAVERSE VALUES TYPE
+			switch v.(type) {
+
+			case map[string]interface{}:
+
+				allKeyNumbers := checkAllKeysAreNumbers(v)
+
+				if allKeyNumbers {
+					// traverse the values to create an array
+					// and removeExtraNumbersLevels in the subsequent levels
+					var results []interface{}
+					for _, allKeyNumbersValue := range v.(map[string]interface{}) {
+						// create temporal map with a fake top level to be in accordance
+						// with the logic of the function
+						dummy := make(map[string]interface{})
+						fake_key := "flatten_fake_key"
+						dummy[fake_key] = allKeyNumbersValue
+						// flat the temporal map
+						flatten := removeExtraNumbersLevels(dummy)
+						// set the results depends on the type of the map returned
+						value, ok := flatten.(map[string]interface{})
+						if ok {
+							results = append(results, value[fake_key])
+						} else {
+							results = append(results, flatten)
+						}
+					}
+					// set the processed subkeys to the result map
+					if len(results) == 0 {
+						c := []string{}
+						result[k] = c
+					} else {
+						result[k] = results
+					}
+				} else {
+					// set a normal key and removeExtraNumbersLevels in the subsequent levels
+					result[k] = removeExtraNumbersLevels(v)
+				}
+			default:
+				// process a normal value
+				result[k] = v
+			}
+		}
+	case string:
+		// return a normal value
+		return etcdmapObject
+	}
+
+	return result
+}
+
+func checkAllKeysAreNumbers(numbersMap interface{}) bool {
+
+	allKeyNumbers := true
+	for k, _ := range numbersMap.(map[string]interface{}) {
+		_, err := strconv.Atoi(k)
+		if err != nil {
+			allKeyNumbers = false
+			break
+		}
+	}
+	return allKeyNumbers
+
+}
+

--- a/src/github.com/mickep76/etcdtool/command/export_command.go
+++ b/src/github.com/mickep76/etcdtool/command/export_command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mickep76/etcdmap"
 	"github.com/mickep76/iodatafmt"
 	"strconv"
+	"sort"
 )
 
 // NewExportCommand returns data from export.
@@ -20,6 +21,7 @@ func NewExportCommand() cli.Command {
 			cli.StringFlag{Name: "format, f", EnvVar: "ETCDTOOL_FORMAT", Value: "JSON", Usage: "Data serialization format YAML, TOML or JSON"},
 			cli.StringFlag{Name: "output, o", Value: "", Usage: "Output file"},
 			cli.BoolFlag{Name: "num-infer-list", Usage: "returns result without extra levels of arrays"},
+			cli.BoolFlag{Name: "infer-types", Usage: "convert to original type if conversion is possible"},
 		},
 		Action: func(c *cli.Context) error {
 			exportCommandFunc(c)
@@ -68,8 +70,8 @@ func exportFunc(dir string, sort bool, file string, f iodatafmt.DataFmt, c *cli.
 	}
 
 	m := etcdmap.Map(resp.Node)
-	if c.Bool("num-infer-list") {
-		m1 := removeExtraNumbersLevels(m)
+	if c.Bool("num-infer-list") || c.Bool("infer-types") {
+		m1 := removeExtraNumbersLevels(m, c.Bool("num-infer-list"), c.Bool("infer-types"))
 		value, ok := m1.(map[string]interface{})
 		if ok {
 			m = value
@@ -83,44 +85,29 @@ func exportFunc(dir string, sort bool, file string, f iodatafmt.DataFmt, c *cli.
 		iodatafmt.Print(m, f)
 	}
 }
-/*
-	Remove extra levels of numbers created in etcd.
- */
-func removeExtraNumbersLevels(etcdmapObject interface{}) interface{} {
+
+// Remove extra levels of numbers created in etcd and infer numbers
+func removeExtraNumbersLevels(etcdmapObject interface{}, numInferList bool, inferTypes bool) interface{} {
 
 	var result map[string]interface{} = make(map[string]interface{})
-	// START TRAVERSE MAP
+	// TRAVERSE MAP
 	switch etcdmapObject.(type) {
 	case map[string]interface{}: // map {string, K} case
 
 		for k, v := range etcdmapObject.(map[string]interface{}) {
-			// START TRAVERSE VALUES TYPE
+			// TRAVERSE VALUES TYPE
 			switch v.(type) {
-
 			case map[string]interface{}:
-
-				allKeyNumbers := checkAllKeysAreNumbers(v)
-
-				if allKeyNumbers {
+				if numInferList && checkAllKeysAreNumbers(v) {
 					// traverse the values to create an array
 					// and removeExtraNumbersLevels in the subsequent levels
 					var results []interface{}
-					for _, allKeyNumbersValue := range v.(map[string]interface{}) {
-						// create temporal map with a fake top level to be in accordance
-						// with the logic of the function
-						dummy := make(map[string]interface{})
-						fake_key := "flatten_fake_key"
-						dummy[fake_key] = allKeyNumbersValue
-						// flat the temporal map
-						flatten := removeExtraNumbersLevels(dummy)
-						// set the results depends on the type of the map returned
-						value, ok := flatten.(map[string]interface{})
-						if ok {
-							results = append(results, value[fake_key])
-						} else {
-							results = append(results, flatten)
-						}
+
+					value, ok := v.(map[string]interface{})
+					if ok {
+						results = extractArrayFromFirstLevel(value,numInferList,numInferList)
 					}
+
 					// set the processed subkeys to the result map
 					if len(results) == 0 {
 						c := []string{}
@@ -130,11 +117,10 @@ func removeExtraNumbersLevels(etcdmapObject interface{}) interface{} {
 					}
 				} else {
 					// set a normal key and removeExtraNumbersLevels in the subsequent levels
-					result[k] = removeExtraNumbersLevels(v)
+					result[k] = removeExtraNumbersLevels(v, numInferList, inferTypes)
 				}
 			default:
-				// process a normal value
-				result[k] = v
+				assignValue(result, k, v, inferTypes)
 			}
 		}
 	case string:
@@ -143,6 +129,70 @@ func removeExtraNumbersLevels(etcdmapObject interface{}) interface{} {
 	}
 
 	return result
+}
+
+func extractArrayFromFirstLevel(originalMap map[string]interface{}, numInferList bool, inferTypes bool) []interface{} {
+	// sort the keys to ensure the list will be in order
+	keys := make([]int, 0)
+	for k, _ := range originalMap {
+		parsedInt , err := strconv.Atoi(k)
+		if err != nil{
+			fatal(err.Error())
+		}else{
+			keys = append(keys, parsedInt)
+		}
+	}
+	sort.Ints(keys)
+	
+	// process the map and extract the first level to build the array
+	var results []interface{}
+	for  _, k := range keys {
+		allKeyNumbersValue := originalMap[strconv.Itoa(k)]
+		// create temporal map with a fake top level to be in accordance
+		// with the logic of the function
+		temporal_map := make(map[string]interface{})
+		fake_key := "flatten_fake_key"
+		temporal_map[fake_key] = allKeyNumbersValue
+		// flat the temporal map
+		flatten := removeExtraNumbersLevels(temporal_map, numInferList, inferTypes)
+		// set the results depends on the type of the map returned
+		value, ok := flatten.(map[string]interface{})
+		if ok {
+			results = append(results, value[fake_key])
+		} else {
+			results = append(results, flatten)
+		}
+	}
+	return results
+}
+
+
+func assignValue(result map[string]interface{}, key string, value interface{}, inferTypes bool) {
+	isString, ok := value.(string)
+	if ok && inferTypes {
+		// process a normal value
+		val, err := strconv.Atoi(isString)
+		if err == nil {
+			result[key] = val
+		} else {
+			val, err := strconv.ParseFloat(isString, 64)
+			if err == nil {
+				result[key] = val
+			} else {
+				val, err := strconv.ParseBool(isString)
+				if err == nil {
+					result[key] = val
+				} else {
+					result[key] = isString
+
+				}
+			}
+		}
+
+	} else {
+		result[key] = value
+	}
+
 }
 
 func checkAllKeysAreNumbers(numbersMap interface{}) bool {

--- a/src/github.com/mickep76/etcdtool/main.go
+++ b/src/github.com/mickep76/etcdtool/main.go
@@ -21,7 +21,6 @@ func main() {
 		cli.StringFlag{Name: "ca", Value: "", EnvVar: "ETCDTOOL_CA", Usage: "Verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "user, u", Value: "", Usage: "User"},
 		cli.StringFlag{Name: "password-file, F", Value: "", Usage: "File path to the user's password"},
-		cli.BoolFlag{Name: "num-infer-list", Usage: "Remove extra levels created of arrays"},
 		cli.DurationFlag{Name: "timeout, t", Value: time.Second, Usage: "Connection timeout"},
 		cli.DurationFlag{Name: "command-timeout, T", Value: 5 * time.Second, Usage: "Command timeout"},
 	}

--- a/src/github.com/mickep76/etcdtool/main.go
+++ b/src/github.com/mickep76/etcdtool/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"time"
-
 	"github.com/codegangsta/cli"
 	"github.com/mickep76/etcdtool/command"
 )
@@ -22,6 +21,7 @@ func main() {
 		cli.StringFlag{Name: "ca", Value: "", EnvVar: "ETCDTOOL_CA", Usage: "Verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "user, u", Value: "", Usage: "User"},
 		cli.StringFlag{Name: "password-file, F", Value: "", Usage: "File path to the user's password"},
+		cli.BoolFlag{Name: "num-infer-list", Usage: "Remove extra levels created of arrays"},
 		cli.DurationFlag{Name: "timeout, t", Value: time.Second, Usage: "Connection timeout"},
 		cli.DurationFlag{Name: "command-timeout, T", Value: 5 * time.Second, Usage: "Command timeout"},
 	}


### PR DESCRIPTION
…rted.

This PR solves the following issue https://github.com/mickep76/etcdtool/issues/22
If --num-infer-list flag is present in the command line of the export, it will export the json removing all the levels of the json that have all the keys as numbers and creating a list of the elements instead.

This is my first time with golang, so i know maybe is not the cleanest or more elegant code but it works. Any suggestion will be really appreciated.
