### PR TITLE
Don't remove extra levels of numbers for empty maps in export command

### DIFF
--- a/examples/host/array.example.com.json
+++ b/examples/host/array.example.com.json
@@ -15,5 +15,6 @@
     }
   },
   "array_test":["first_elem","second_elem","third_elem"],
-  "array_two_levels":[["first_elem","second_elem"],["third_elem"], 5, 5.0, true]
+  "array_two_levels":[["first_elem","second_elem"],["third_elem"], 5, 5.0, true],
+  "map_empty":{}
 }

--- a/src/github.com/mickep76/etcdtool/command/export_command.go
+++ b/src/github.com/mickep76/etcdtool/command/export_command.go
@@ -197,6 +197,11 @@ func assignValue(result map[string]interface{}, key string, value interface{}, i
 
 func checkAllKeysAreNumbers(numbersMap interface{}) bool {
 
+    // zero length map shouldn't be regarded as an array
+    if (len(numbersMap.(map[string]interface{})) == 0) {
+        return false
+    }
+
 	allKeyNumbers := true
 	for k, _ := range numbersMap.(map[string]interface{}) {
 		_, err := strconv.Atoi(k)


### PR DESCRIPTION
I used etcdtool to export a docker compose file, but the below config wasn't able to export from etcd , though used the option --num-infer-list, 

```yaml
volumes:
  appres: {}
  dbdata: {}
```
it was exported as follows and be invalid for docker-compose.

```yaml
volumes:
  appres: []
  dbdata: []
```

This PR solves this issue. Any suggestion will be appreciated.

