### PR TITLE
Allow to keep the format for custom paths

### DIFF
--- a/examples/host/array.example.com.json
+++ b/examples/host/array.example.com.json
@@ -7,10 +7,12 @@
       "hwaddr": "00:01:02:03:04:05",
       "ip": "192.168.0.2",
       "netmask": "255.255.255.0",
-      "array_insice_map":[
+      "array_inside_map":[
         { "key1": "value1"},
         { "key2": "value2"},
-        { "key3": "value3"}
+        { "key3": "value3"},
+        { "key": "another_value_fro_key","value":"true"},
+        { "key4": "True"}
       ]
     }
   },


### PR DESCRIPTION
Sometimes you need to infer types in your data read from etcd, but you need to keep the string format for some fields. With this pull request, you can specify a list of paths with regex to keep the string format for these custom paths.

Example of usage:

- Import step:
etcdtool import --replace -y array_test etcdtool/examples/host/array.example.com.json

- Export without infer types in the values of interfaces.eth0.array_inside_map from the json loaded:
etcdtool export array_test --infer-types --num-infer-list --keep-format-path interfaces.eth0.array_inside_map.key* --keep-format-path interfaces.eth0.array_inside_map.value*