### PR TITLE
Add new command just for seeing only keys, not values: etcdtool ls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /.build
+/build
 /bin
 /pkg

--- a/command/ls_command.go
+++ b/command/ls_command.go
@@ -1,0 +1,100 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/coreos/etcd/client"
+	"github.com/mickep76/etcdmap"
+)
+
+// NewLsCommand returns keys from directory
+func NewLsCommand() cli.Command {
+	return cli.Command{
+		Name:  "ls",
+		Usage: "list a directory",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "output, o", Value: "", Usage: "Output file"},
+		},
+		Action: func(c *cli.Context) error {
+			lsCommandFunc(c)
+			return nil
+		},
+	}
+}
+
+// lsCommandFunc does what `etcdctl ls -p` do
+func lsCommandFunc(c *cli.Context) {
+	if len(c.Args()) == 0 {
+		fatal("You need to specify directory")
+	}
+	dir := c.Args()[0]
+
+	// Remove trailing slash.
+	if dir != "/" {
+		dir = strings.TrimRight(dir, "/")
+	}
+	infof("Using dir: %s", dir)
+
+	// Load configuration file.
+	e := loadConfig(c)
+
+	// New dir API.
+	ki := newKeyAPI(e)
+
+	lsFunc(dir, c.String("output"), c, ki)
+}
+
+func lsFunc(dir string, file string, c *cli.Context, ki client.KeysAPI) {
+	ctx, cancel := contextWithCommandTimeout(c)
+	resp, err := ki.Get(ctx, dir, &client.GetOptions{Sort: true, Recursive: false})
+	cancel()
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	m := etcdmap.Map(resp.Node)
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		isDir := false
+		switch m[k].(type) {
+			case map[string]interface {}:
+				isDir = true
+			default:
+				// nothing to do
+		}
+
+		if isDir {
+			keys = append(keys, k + "/")
+		} else {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var result strings.Builder
+	for i, k := range(keys) {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		result.WriteString("/")
+		result.WriteString(k)
+		i++
+	}
+
+	if file != "" {
+		file, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			fatal(err.Error())
+		}
+		file.WriteString(result.String())
+		file.WriteString("\n")
+	} else {
+		fmt.Printf("%s\n", result.String())
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ func readStandardConfig() Config {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
 		keyvals := strings.Split(line, " ")
 		if len(keyvals) != 2 {
 			log.Fatalf("Bad line in config file %s, line: %s", cfg, line)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	app.Commands = []cli.Command{
 		command.NewImportCommand(),
 		command.NewExportCommand(),
+		command.NewLsCommand(),
 		command.NewEditCommand(),
 		command.NewValidateCommand(),
 		command.NewTreeCommand(),

--- a/main.go
+++ b/main.go
@@ -1,14 +1,59 @@
 package main
 
 import (
+	"bufio"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/codegangsta/cli"
 	"github.com/mickep76/etcdtool/command"
-
-	"os"
-	"time"
 )
 
+type Config struct {
+	peers string
+}
+
+func readStandardConfig() Config {
+	var ret Config
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg := path.Join(dir, ".etcdtool.conf")
+
+	file, err := os.Open(cfg)
+	if err != nil {
+		return ret
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		keyvals := strings.Split(line, " ")
+		if len(keyvals) != 2 {
+			log.Fatalf("Bad line in config file %s, line: %s", cfg, line)
+		}
+		if keyvals[0] == "peers" {
+			ret.peers = keyvals[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	return ret
+}
+
 func main() {
+	cfg := readStandardConfig()
+	defaultPeers := "http://127.0.0.1:4001,http://127.0.0.1:2379"
+	if len(cfg.peers) > 0 {
+		defaultPeers = cfg.peers
+	}
+
 	app := cli.NewApp()
 	app.Name = "etcdtool"
 	app.Version = Version
@@ -16,7 +61,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "config, c", EnvVar: "ETCDTOOL_CONFIG", Usage: "Configuration file"},
 		cli.BoolFlag{Name: "debug, d", Usage: "Debug"},
-		cli.StringFlag{Name: "peers, p", Value: "http://127.0.0.1:4001,http://127.0.0.1:2379", EnvVar: "ETCDTOOL_PEERS", Usage: "Comma-delimited list of hosts in the cluster"},
+		cli.StringFlag{Name: "peers, p", Value: defaultPeers, EnvVar: "ETCDTOOL_PEERS", Usage: "Comma-delimited list of hosts in the cluster"},
 		cli.StringFlag{Name: "cert", Value: "", EnvVar: "ETCDTOOL_CERT", Usage: "Identify HTTPS client using this SSL certificate file"},
 		cli.StringFlag{Name: "key", Value: "", EnvVar: "ETCDTOOL_KEY", Usage: "Identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca", Value: "", EnvVar: "ETCDTOOL_CA", Usage: "Verify certificates of HTTPS-enabled servers using this CA bundle"},


### PR DESCRIPTION
I needed to select a subtree in a large directory in order to edit it.  
Watching the full output of the export command in this case is not so convenient.  
  
So, I added command analogue 
```
etcdctl ls -p /
```
  
Example:  
```
$ etcdtool ls /
/dir1/
/dir2/

$ etcdtool ls /dir2
/key1
/key2
```
